### PR TITLE
a64.sh:  line 42: tar -xvf: command not found [FIXED]

### DIFF
--- a/a64.sh
+++ b/a64.sh
@@ -21,7 +21,6 @@ else
 	archname=$(dpkg --print-architecture)
 	tag="v1.0.0"
 	ex="tar.gz"
-	unpack="tar -xvf"
 	file="openjdk-11.0.1"
 	
 	#Actual installation
@@ -39,7 +38,7 @@ else
     	ee "\e[32m[*] \e[34mExtracting JDK to ""$PREFIX""/share "
     	cd "$PREFIX"/share || exit
     	pkg install tar unzip -y
-    	"$unpack" openjdk-11."$ex"
+    	tar -xvf openjdk-11."$ex"
     	
     	ee "\e[32m[*] \e[34mSeting-up environment variable %JAVA_HOME%..."
     	export JAVA_HOME="$PREFIX"/share/"$file"


### PR DESCRIPTION
a64.sh script failed to extract the downloaded JDK. I am not familiar with shell scripting. But, I have a lot of programming experience. So, from my experience I think that when one command assigned to the variable as a value, the shell assumes that command as a normal data(including spaces between "tar" and "-xvf") and not as a command. So, you should directly write the command instead of assigning in one variable and then putting that variable or there may be something other ways available(I don't know).

Though there is nothing extraction happened, a64.sh script skipped that and went to the next operation i.e. Setting-up environment variable %JAVA_HOME%... and Cleaning up temporary files.